### PR TITLE
Fix DDC checkbox handling

### DIFF
--- a/gosa-plugins/goto/admin/systems/goto/class_workstationService.inc
+++ b/gosa-plugins/goto/admin/systems/goto/class_workstationService.inc
@@ -177,9 +177,10 @@ class workservice extends plugin
         }
 
         if(preg_match("/\+/",$this->gotoXHsync)){
-          $this->AutoSync = true;
           $this->gotoXHsync = preg_replace("/\+/","-",$this->gotoXHsync);
           $this->gotoXVsync = preg_replace("/\+/","-",$this->gotoXVsync);
+        } else {
+          $this->AutoSync = false;
         }
 
         if (isset($this->attrs['gotoXHsync']) && isset($this->attrs['gotoXVsync'])) {
@@ -214,12 +215,9 @@ class workservice extends plugin
         /* Load hardware list */
         $this->loadHardwareList();
 
-        if (preg_match("/\+/",$this->gotoXHsync)){
+        if (empty($this->gotoXHsync)){
           $this->AutoSync = true;
-          $this->gotoXHsync = preg_replace("/\+/","-",$this->gotoXHsync);
-          $this->gotoXVsync = preg_replace("/\+/","-",$this->gotoXVsync);
         }
-
 
         if($this->is_account && !$this->view_logged){
             $this->view_logged = TRUE;
@@ -670,18 +668,6 @@ class workservice extends plugin
                     }
                 }
             }
-        }
-    }
-
-
-    function PrepareForCopyPaste($source)
-    {
-        plugin::PrepareForCopyPaste($source);
-
-        if(preg_match("/\+/",$this->gotoXHsync)){
-            $this->AutoSync = true;
-            $this->gotoXHsync = preg_replace("/\+/","-",$this->gotoXHsync);
-            $this->gotoXVsync = preg_replace("/\+/","-",$this->gotoXVsync);
         }
     }
 }


### PR DESCRIPTION
Commit 975d0a36b2b6f313cf0034d082f5c87537b475a2 introduced a regression: The DDC checkbox will always be reset to `checked` when opening the system.
As a result just opening and closing a workstation object may change the workstation's configuration.

By changing the `AutoSync` variable to `true` the logic of the code also has to be inverted - this is done both for the `workservice` and the `execute` function by this patch.
I wasn't sure about the `PrepareForCopyPaste` function: It didn't seem to have any effect on the copied object, but as it's code is also affected I decided to remove it. The `execute` function change may also need review, but at least it didn't seem to break anything...

What this patch doesn't fix (but what was broken before):
- The copied system doesn't contain the `gotoXHsync` and `gotoYHsync` attributes, resulting in strange behavior of the checkbox when opening the copied object (the checkbox can only be clicked when changing to another tab and back again).
